### PR TITLE
Refactored world gen

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -17,8 +17,8 @@ config/icon="res://icon.svg"
 
 [autoload]
 
-BetterTerrain="*res://addons/better-terrain/BetterTerrain.gd"
 EventBus="*res://scripts/EventBus.gd"
+BetterTerrain="*res://addons/better-terrain/BetterTerrain.gd"
 
 [display]
 

--- a/scenes/terraria.tscn
+++ b/scenes/terraria.tscn
@@ -264,8 +264,8 @@ texture = ExtResource("3_340ap")
 
 [sub_resource type="TileSet" id="TileSet_rf7n8"]
 physics_layer_0/collision_layer = 1
-sources/0 = SubResource("TileSetAtlasSource_hkb7f")
 sources/1 = SubResource("TileSetAtlasSource_x1xxr")
+sources/0 = SubResource("TileSetAtlasSource_hkb7f")
 metadata/_better_terrain = {
 "decoration": ["Decoration", Color(0.411765, 0.411765, 0.411765, 1), 3, [], {
 "path": "res://addons/better-terrain/icons/Decoration.svg"

--- a/scripts/world_gen/world_gen.gd
+++ b/scripts/world_gen/world_gen.gd
@@ -7,7 +7,6 @@ extends Node2D
 
 @onready var tile_map = $TileMap
 
-
 var width : int = 1000
 var height: int = 100
 
@@ -23,45 +22,55 @@ var white_tile = Vector2(5,0)
 var front_layer = 1
 var back_layer = 0
 
-func _ready():
+func build_cells(width: int, height: int) -> Dictionary:
 	var noise : FastNoiseLite = noise_image.noise
 	var noise_height 
 	var cave_noise : FastNoiseLite = cave_text.noise
 	var ore_noise : FastNoiseLite = ore_text.noise
-	for x in (width):
-		
-		
+
+	var x = 0
+	var y = 0
+	var map_tiles = width * height
+
+	for tile in (map_tiles):
 		noise_height = int(noise.get_noise_1d(x) * 10)
+
+		#setting background dirt tiles
+		if y > 5:
+			tile_map.set_cell(back_layer,Vector2(x, noise_height+y), 0,Vector2(6, 0))
+
+		if cave_noise.get_noise_2d(x,y) < 0.4:
+			if (ore_noise.get_noise_2d(x,y) > 0.6) and y > 20:
+				ore_arr.append(Vector2(x,y))
+			else:
+				tile_arr.append(Vector2(x, noise_height+y))
+
+		y += 1
 		
-		# filling in the first
-		for y in height:
-			
-			#setting background dirt tiles
-			if y > 5:
-				tile_map.set_cell(back_layer,Vector2(x, noise_height+y), 0,Vector2(6, 0))
+		#Done column, move row
+		if y > height:
+			#top layer of the terrain
+			if tile_arr.find(Vector2(x, noise_height+1)) != -1:
+				tile_arr.append(Vector2(x, noise_height))
+				var rand_num = randi_range(0,20)
+				if rand_num == 1:
+					tile_map.set_cell(front_layer, Vector2(x, noise_height-1),1, Vector2(0,0))
+			y = 0
+			x += 1
 		
-			
-			if cave_noise.get_noise_2d(x,y) < 0.4:
-				if (ore_noise.get_noise_2d(x,y) > 0.6) and y > 20:
-					ore_arr.append(Vector2(x,y))
-					#BetterTerrain.set_cell(tile_map, front_layer,Vector2(x,y), 1)
-					#tile_map.set_cell(front_layer,Vector2(x, noise_height+y), 0,Vector2(6, 1))
-				else:
-					tile_arr.append(Vector2(x, noise_height+y))
-			
-		#top layer of the terrain
-		if tile_arr.find(Vector2(x, noise_height+1)) != -1:
-			tile_arr.append(Vector2(x, noise_height))
-			var rand_num = randi_range(0,20)
-			if rand_num == 1:
-				tile_map.set_cell(front_layer, Vector2(x, noise_height-1),1, Vector2(0,0))
+		#All rows completed, thus done
+		if x > width:
+			break;
 
+	return {"tile_arr" = tile_arr, "ore_arr" = ore_arr}
 
+func _ready():
+	var cells = build_cells(width, height)
+	fill_in_map(cells.tile_arr, cells.ore_arr)
 
+func fill_in_map(tile_arr: Array, ore_arr: Array) -> void:
 	BetterTerrain.set_cells(tile_map, front_layer,tile_arr, 0)
-	BetterTerrain.update_terrain_cells(tile_map, front_layer,tile_arr,true )
-	
 	BetterTerrain.set_cells(tile_map, front_layer,ore_arr, 1)
-	BetterTerrain.update_terrain_cells(tile_map, front_layer,ore_arr,true )
+	BetterTerrain.update_terrain_cells(tile_map, front_layer, (tile_arr + ore_arr), false)
 
 


### PR DESCRIPTION
In this scenario, the code does not need the `true` for updating surrounding tiles. This cuts generating by at least half when I benchmarked it.

```gdscript
BetterTerrain.update_terrain_cells(tile_map, front_layer,ore_arr,true )
```

I honestly have no idea how BetterTerrain knows that Atlas source id 0 is being used when using the `.set_cells` or how to change the atlas source id when wanting to add `.set_cells` which is why I left your direct tilemap manipulation in the `build_cells()` function.

Enjoy!